### PR TITLE
Update to Mosca V2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 sudo: false
 language: node_js
 env:
-  - CXX="g++-4.8"
+  - CXX=g++-4.8
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
     packages:
-    - g++-4.8
-    - gcc-4.8
+      - g++-4.8
 node_js:
   - "8"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: node_js
+env:
+  - CXX="g++-4.8"
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+    - gcc-4.8
+node_js:
+  - "8"
+  - "6"
+before_script:
+  - npm install -g node-red
+  - npm link node-red

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - gcc-4.8
 node_js:
   - "8"
-  - "6"
 before_script:
   - npm install -g node-red
   - npm link node-red

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+services:
+  - mongodb      
 node_js:
   - "8"
 before_script:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Because this MQTT broker is implemented by Node.js, you can use MQTT-in and MQTT
 
 [![Build Status](https://travis-ci.org/martin-doyle/node-red-contrib-mosca.svg?branch=master)](https://travis-ci.org/martin-doyle/node-red-contrib-mosca)
 
+[![Dependency Status](https://david-dm.org/martin-doyle/node-red-contrib-mosca.svg)](https://david-dm.org/martin-doyle/node-red-contrib-mosca)
+[![devDependency Status](https://david-dm.org/martin-doyle/node-red-contrib-mosca/dev-status.svg)](https://david-dm.org/martin-doyle/node-red-contrib-mosca#info=devDependencies)
+
+[![Open Source Love](https://badges.frapsoft.com/os/mit/mit.svg?v=102)](https://github.com/ellerbrock/open-source-badge/)
+
 ## Flows
 Once you just put this node on Node-RED and hit deploy button, MQTT Broker will run on your Node-RED.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ MQTT Broker server on Node-RED
 
 Because this MQTT broker is implemented by Node.js, you can use MQTT-in and MQTT-out nodes without MQTT environment like Mosquitto.
 
+[![Build Status](https://travis-ci.org/martin-doyle/node-red-contrib-mosca.svg?branch=master)](https://travis-ci.org/martin-doyle/node-red-contrib-mosca)
+
 ## Flows
 Once you just put this node on Node-RED and hit deploy button, MQTT Broker will run on your Node-RED.
 

--- a/mosca.js
+++ b/mosca.js
@@ -54,10 +54,26 @@ module.exports = function (RED) {
         server.authenticate = authenticate
     }
 
+    server.on('error', function (err) {
+      node.send(err);
+    });
+
+    server.on('clientConnecting', function (client) {
+      var msg = {
+        topic: 'clientConnecting',
+        payload: {
+          client: client
+        }
+      };
+      node.send(msg);
+    });
+    
     server.on('clientConnected', function (client) {
       var msg = {
         topic: 'clientConnected',
-        payload: client
+        payload: {
+          client: client
+        }
       };
       node.send(msg);
     });
@@ -65,7 +81,9 @@ module.exports = function (RED) {
     server.on('clientDisconnected', function (client) {
       var msg = {
         topic: 'clientDisconnected',
-        payload: client
+        payload: {
+          client: client
+        }
       };
       node.send(msg);
     });

--- a/mosca.js
+++ b/mosca.js
@@ -39,8 +39,7 @@ module.exports = function (RED) {
     node.log('Binding mosca mqtt server on port: ' + this.mqtt_port);
     var server = new mosca.Server(moscaSettings, function (err) {
         if (err) {
-            err.msg = 'Error binding mosca mqtt server, cause: ' + err.toString();
-            node.error(err);
+            node.error('Error binding mosca mqtt server, cause: ' + err.toString());
         }
     });
 
@@ -55,7 +54,12 @@ module.exports = function (RED) {
     }
 
     server.on('error', function (err) {
-      node.send(err);
+      node.status({
+        fill: "red",
+        shape: "dot",
+        text: "disconnected"
+      });
+      node.error('Error starting mosca mqtt server, cause: ' + err.toString());
     });
 
     server.on('clientConnecting', function (client) {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,13 @@
 {
-
   "name": "node-red-contrib-mqtt-broker",
   "version": "0.2.1",
   "description": "MQTT Broker server on Node-RED",
-
   "dependencies": {
     "mosca": "^2.7.0"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-
     "url": "https://github.com/zuhito/node-red-contrib-mqtt-broker.git"
   },
   "keywords": [
@@ -18,6 +15,9 @@
     "mosca",
     "mqtt"
   ],
+  "scripts": {
+    "test": "mocha test/**/*_spec.js"
+  },
   "node-red": {
     "nodes": {
       "mosca-mqtt-broker": "mosca.js"
@@ -31,5 +31,8 @@
     {
       "name": "Jochen Scheib"
     }
-  ]
+  ],
+  "devDependencies": {
+    "node-red-node-test-helper": "^0.1.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.4",
   "description": "MQTT Broker server on Node-RED",
   "dependencies": {
-    "mosca": "^2.7.0"
+    "mosca": "^2.8.0"
   },
   "license": "MIT",
   "repository": {
@@ -16,7 +16,7 @@
     "mqtt"
   ],
   "scripts": {
-    "test": "mocha test/**/*_spec.js"
+    "test": "npm link node-red & mocha test/**/*_spec.js"
   },
   "node-red": {
     "nodes": {

--- a/test/mosca_spec.js
+++ b/test/mosca_spec.js
@@ -1,0 +1,154 @@
+var should = require('should');
+var helper = require('node-red-node-test-helper');
+var moscaNode = require('../mosca.js');
+var mqttNode = require('../node_modules/node-red/nodes/core/io/10-mqtt.js');
+var injectNode = require('../node_modules/node-red/nodes/core/core/20-inject.js');
+
+
+describe('MQTT Broker Node', function () {
+    before(function (done) {
+        helper.startServer(done);
+    });
+    afterEach(function () {
+        helper.unload();
+    });
+
+    it('should be loaded', function (done) {
+        var flow = [{
+            id: 'n1',
+            type: 'mosca in',
+            mqtt_port: '1883',
+            mqtt_ws_port: '8080',
+            name: 'Mosca 1883'
+        }];
+        helper.load(moscaNode, flow, function () {
+            var n1 = helper.getNode('n1');
+            n1.on('error', function (err) {
+                console.log(err);
+            });
+            n1.should.have.property('name', 'Mosca 1883');
+            done();
+        });
+    });
+    it('should connect an mqtt client', function (done) {
+        this.timeout(10000); // have to wait for the inject with delay of two seconds
+
+        var timestamp = new Date();
+        timestamp.setSeconds(timestamp.getSeconds() + 1);
+
+        helper.load([injectNode, moscaNode, mqttNode], [{
+                    id: 'n1',
+                    type: 'mosca in',
+                    mqtt_port: '1883',
+                    mqtt_ws_port: '8080',
+                    name: 'Mosca 1883',
+                    wires: [
+                        ['n2']
+                    ]
+                },
+                {
+                    id: 'n2',
+                    type: 'helper'
+                }, {
+                    id: 'n3',
+                    type: 'mqtt in',
+                    name: 'Mosca 1883',
+                    topic: 'test1883',
+                    broker: 'b1'
+                }, {
+                    id: 'b1',
+                    type: 'mqtt-broker',
+                    name: 'Broker',
+                    broker: 'localhost',
+                    port: '1883'
+                }
+            ],
+            function () {
+                var n1 = helper.getNode('n1');
+                var n2 = helper.getNode('n2');
+                n2.on('input', function (msg) {
+                    msg.should.have.property('topic', 'clientConnected');
+                    done();
+                });
+            });
+    });
+    it('should connect 2 mqtt clients on 2 servers', function (done) {
+        this.timeout(10000); // have to wait for the inject with delay of two seconds
+
+        var timestamp = new Date();
+        timestamp.setSeconds(timestamp.getSeconds() + 1);
+
+        helper.load([injectNode, moscaNode, mqttNode], [{
+                    id: 'n1',
+                    type: 'mosca in',
+                    mqtt_port: '1883',
+                    mqtt_ws_port: '8080',
+                    name: 'Mosca 1883',
+                    wires: [
+                        ['n2']
+                    ]
+                },
+                {
+                    id: 'n2',
+                    type: 'helper'
+                }, {
+                    id: 'n3',
+                    type: 'mqtt in',
+                    name: 'Mosca 1883',
+                    topic: 'test1883',
+                    broker: 'b1'
+                }, {
+                    id: 'b1',
+                    type: 'mqtt-broker',
+                    name: 'Broker',
+                    broker: 'localhost',
+                    port: '1883'
+                }, {
+                    id: 'n11',
+                    type: 'mosca in',
+                    mqtt_port: '1884',
+                    mqtt_ws_port: '8081',
+                    name: 'Mosca 1884',
+                    wires: [
+                        ['n12']
+                    ]
+                }, {
+                    id: 'n12',
+                    type: 'helper'
+                }, {
+                    id: 'n13',
+                    type: 'mqtt in',
+                    name: 'Mosca 1884',
+                    topic: 'test1884',
+                    broker: 'b11'
+                }, {
+                    id: 'b11',
+                    type: 'mqtt-broker',
+                    name: 'Broker',
+                    broker: 'localhost',
+                    port: '1884'
+                }, 
+            ],
+            function () {
+                var i = 0;
+                var n1 = helper.getNode('n1');
+                var n2 = helper.getNode('n2');
+                n2.on('input', function (msg) {
+                    msg.should.have.property('topic', 'clientConnected');
+                    i++;
+                    if (i == 2) {
+                        done();
+                    }
+                });
+                var n11 = helper.getNode('n11');
+                var n12 = helper.getNode('n12');
+                n12.on('input', function (msg) {
+                    msg.should.have.property('topic', 'clientConnected');
+                    i++;
+                    if (i == 2) {
+                        done();
+                    }
+                });
+            });
+    });
+});

--- a/test/mosca_spec.js
+++ b/test/mosca_spec.js
@@ -1,8 +1,6 @@
-var should = require('should');
 var helper = require('node-red-node-test-helper');
 var moscaNode = require('../mosca.js');
 var mqttNode = require('../node_modules/node-red/nodes/core/io/10-mqtt.js');
-var injectNode = require('../node_modules/node-red/nodes/core/core/20-inject.js');
 
 
 describe('MQTT Broker Node', function () {
@@ -36,7 +34,7 @@ describe('MQTT Broker Node', function () {
         var timestamp = new Date();
         timestamp.setSeconds(timestamp.getSeconds() + 1);
 
-        helper.load([injectNode, moscaNode, mqttNode], [{
+        helper.load([moscaNode, mqttNode], [{
                     id: 'n1',
                     type: 'mosca in',
                     mqtt_port: '1883',
@@ -64,7 +62,6 @@ describe('MQTT Broker Node', function () {
                 }
             ],
             function () {
-                var n1 = helper.getNode('n1');
                 var n2 = helper.getNode('n2');
                 n2.on('input', function (msg) {
                     msg.should.have.property('topic', 'clientConnected');
@@ -78,7 +75,7 @@ describe('MQTT Broker Node', function () {
         var timestamp = new Date();
         timestamp.setSeconds(timestamp.getSeconds() + 1);
 
-        helper.load([injectNode, moscaNode, mqttNode], [{
+        helper.load([moscaNode, mqttNode], [{
                     id: 'n1',
                     type: 'mosca in',
                     mqtt_port: '1883',
@@ -127,25 +124,23 @@ describe('MQTT Broker Node', function () {
                     name: 'Broker',
                     broker: 'localhost',
                     port: '1884'
-                }, 
+                }
             ],
             function () {
                 var i = 0;
-                var n1 = helper.getNode('n1');
                 var n2 = helper.getNode('n2');
                 n2.on('input', function (msg) {
                     msg.should.have.property('topic', 'clientConnected');
                     i++;
-                    if (i == 2) {
+                    if (i === 2) {
                         done();
                     }
                 });
-                var n11 = helper.getNode('n11');
                 var n12 = helper.getNode('n12');
                 n12.on('input', function (msg) {
                     msg.should.have.property('topic', 'clientConnected');
                     i++;
-                    if (i == 2) {
+                    if (i === 2) {
                         done();
                     }
                 });


### PR DESCRIPTION
The new Mosca version catches error like port already in use. This makes sure that Node-Red does start even if there is a Mosca starting error.
I added a test first file.  The file .travis.yml is only necessary if an automated test is required. I also added some symbols in the readme.md. This is only useful if the automated test in Travis is setup and the links are updated.